### PR TITLE
 feat(ai): Implement LLM Factory and Extractor Agent

### DIFF
--- a/ai/Modelfile.extractor
+++ b/ai/Modelfile.extractor
@@ -1,0 +1,4 @@
+FROM gemma2:2b
+PARAMETER temperature 0.1
+PARAMETER num_ctx 8192
+SYSTEM "You are an expert data-extraction agent. When given raw document text (which may come from OCR with noise, misspellings, or broken formatting), you reason step-by-step: first identify the document type, then plan which fields to extract, then extract each field with a confidence score. Always output a single valid JSON object. If a field is unreadable, mark it with confidence 0.0. Never guess — if uncertain, state the ambiguity. Do not include conversational filler."

--- a/ai/agent_extractor.py
+++ b/ai/agent_extractor.py
@@ -1,0 +1,301 @@
+"""
+Extractor Agent — ai/agent_extractor.py
+
+A *thinking* extraction agent (not a dumb parser) that reasons about
+document content, identifies structured data fields, and returns a
+validated Pydantic model.
+
+Architecture
+────────────
+  raw text  ──►  ExtractorAgent.extract()
+                       │
+                       ├─ 1. THINK  – reason about what the document is
+                       ├─ 2. PLAN   – decide which fields to extract
+                       ├─ 3. EXTRACT – pull structured data w/ chain-of-thought
+                       └─ 4. VALIDATE – parse into Pydantic, retry on failure
+                       │
+                  ExtractionResult (validated)
+
+The agent uses a multi-step chain-of-thought prompt so the LLM
+*reasons* before answering — critical for messy OCR / scanned PDFs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Optional
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+from pydantic import BaseModel, Field, ValidationError
+
+from ai.llm_config import get_llm, MODEL_EXTRACTOR
+
+logger = logging.getLogger(__name__)
+
+# ─── Maximum retry attempts for structured output parsing ────────────
+_MAX_RETRIES = 2
+
+
+# =====================================================================
+#  Pydantic schema — the contract for every extraction result
+# =====================================================================
+
+class ExtractedEntity(BaseModel):
+    """A single named entity or data point extracted from a document."""
+
+    field_name: str = Field(..., description="Canonical field name (e.g. 'full_name', 'date_of_birth').")
+    value: str = Field(..., description="Extracted value exactly as it appears.")
+    confidence: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=1.0,
+        description="Agent's self-assessed confidence in the extraction (0-1).",
+    )
+    reasoning: str = Field(
+        default="",
+        description="Brief reasoning for why this value was chosen.",
+    )
+
+
+class ExtractionResult(BaseModel):
+    """Complete extraction output for one document."""
+
+    document_type: str = Field(
+        ..., description="Identified document type (e.g. 'invoice', 'identity_card', 'medical_record')."
+    )
+    summary: str = Field(
+        default="", description="One-sentence summary of the document content."
+    )
+    entities: list[ExtractedEntity] = Field(
+        default_factory=list, description="All extracted entities."
+    )
+    raw_thinking: str = Field(
+        default="",
+        description="The agent's chain-of-thought reasoning (kept for audit).",
+    )
+
+
+# =====================================================================
+#  System prompt — instructs the LLM to *think*, not just parse
+# =====================================================================
+
+_SYSTEM_PROMPT = """\
+You are an expert data-extraction agent for the ClutterKill system.
+Your job is to extract structured information from raw document text
+that may come from OCR (noisy, misspelled, broken formatting).
+
+IMPORTANT: You are a THINKING agent.  Before extracting, you MUST
+reason step-by-step about the document.
+
+Follow this exact protocol:
+
+### Step 1 — IDENTIFY
+Determine the document type (invoice, ID card, contract, medical
+record, correspondence, etc.).  State your reasoning.
+
+### Step 2 — PLAN
+List the fields you expect to find for this document type.
+Mention any fields that are likely missing or corrupted.
+
+### Step 3 — EXTRACT
+For each field, extract the value.  If the text is ambiguous,
+state the ambiguity and pick the most likely interpretation.
+Assign a confidence score (0.0–1.0) to each extraction.
+
+### Step 4 — OUTPUT
+Return your answer as a single JSON object with this schema:
+{{
+  "thinking": "<your full chain-of-thought from steps 1-3>",
+  "document_type": "<identified type>",
+  "summary": "<one-sentence summary>",
+  "entities": [
+    {{
+      "field_name": "<canonical_field_name>",
+      "value": "<extracted value>",
+      "confidence": <0.0-1.0>,
+      "reasoning": "<why you chose this value>"
+    }}
+  ]
+}}
+
+Rules:
+- Output ONLY the JSON object, no markdown fences, no extra text.
+- Use snake_case for field_name values.
+- If a field is completely unreadable, set confidence to 0.0 and
+  value to "UNREADABLE".
+- Preserve original values exactly — do NOT normalize dates or names
+  unless they are clearly OCR errors.
+"""
+
+_EXTRACTION_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        ("system", _SYSTEM_PROMPT),
+        ("human", "Extract structured data from the following document text:\n\n---\n{document_text}\n---"),
+    ]
+)
+
+
+# =====================================================================
+#  Repair prompt — used when JSON is malformed on the first try
+# =====================================================================
+
+_REPAIR_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        (
+            "system",
+            "You previously attempted to extract data but your JSON was invalid. "
+            "Fix the JSON below so it matches the required schema. "
+            "Output ONLY valid JSON, nothing else.",
+        ),
+        ("human", "Broken output:\n{broken_json}\n\nValidation error:\n{error}"),
+    ]
+)
+
+
+# =====================================================================
+#  ExtractorAgent
+# =====================================================================
+
+class ExtractorAgent:
+    """Thinking extraction agent backed by a local Ollama LLM.
+
+    Usage::
+
+        agent = ExtractorAgent()
+        result = agent.extract("John Doe, born 1990-05-12 …")
+        print(result.entities)
+    """
+
+    def __init__(self, llm: Any | None = None) -> None:
+        self._llm = llm or get_llm(model=MODEL_EXTRACTOR)
+        self._chain = _EXTRACTION_PROMPT | self._llm | StrOutputParser()
+        self._repair_chain = _REPAIR_PROMPT | self._llm | StrOutputParser()
+
+    # ── public API ───────────────────────────────────────────────────
+
+    def extract(self, document_text: str) -> ExtractionResult:
+        """Run the full think→plan→extract→validate pipeline.
+
+        Parameters
+        ----------
+        document_text : str
+            Raw text content of the document (e.g. from OCR or PDF parser).
+
+        Returns
+        -------
+        ExtractionResult
+            Validated extraction with entities, confidence scores, and
+            the agent's chain-of-thought reasoning.
+
+        Raises
+        ------
+        ExtractionError
+            If the LLM fails to produce valid JSON after all retries.
+        """
+        logger.info("ExtractorAgent: starting extraction (%d chars)", len(document_text))
+
+        raw_output = self._chain.invoke({"document_text": document_text})
+        logger.debug("Raw LLM output:\n%s", raw_output)
+
+        # Try to parse → validate → retry loop
+        result = self._parse_with_retries(raw_output)
+        logger.info(
+            "Extraction complete: type=%s  entities=%d",
+            result.document_type,
+            len(result.entities),
+        )
+        return result
+
+    # ── internals ────────────────────────────────────────────────────
+
+    def _parse_with_retries(self, raw_output: str) -> ExtractionResult:
+        """Attempt to parse the LLM output into an ExtractionResult.
+
+        If JSON is malformed, ask the LLM to repair it up to
+        ``_MAX_RETRIES`` times.
+        """
+        last_error: Exception | None = None
+        current_output = raw_output
+
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                data = self._extract_json(current_output)
+                return self._validate(data)
+            except (json.JSONDecodeError, ValidationError, ValueError) as exc:
+                last_error = exc
+                logger.warning(
+                    "Parse attempt %d/%d failed: %s",
+                    attempt + 1,
+                    _MAX_RETRIES + 1,
+                    exc,
+                )
+                if attempt < _MAX_RETRIES:
+                    current_output = self._repair_chain.invoke(
+                        {"broken_json": current_output, "error": str(exc)}
+                    )
+
+        raise ExtractionError(
+            f"Failed to parse extraction after {_MAX_RETRIES + 1} attempts: {last_error}"
+        ) from last_error
+
+    @staticmethod
+    def _extract_json(text: str) -> dict:
+        """Pull the first JSON object out of the LLM response."""
+        # Strip markdown code fences if the model wraps them anyway
+        cleaned = text.strip()
+        if cleaned.startswith("```"):
+            # Remove opening fence (```json or ```)
+            first_newline = cleaned.index("\n")
+            cleaned = cleaned[first_newline + 1 :]
+        if cleaned.endswith("```"):
+            cleaned = cleaned[:-3]
+        return json.loads(cleaned.strip())
+
+    @staticmethod
+    def _validate(data: dict) -> ExtractionResult:
+        """Map raw JSON dict → ExtractionResult pydantic model."""
+        entities = [
+            ExtractedEntity(**ent) for ent in data.get("entities", [])
+        ]
+        return ExtractionResult(
+            document_type=data.get("document_type", "unknown"),
+            summary=data.get("summary", ""),
+            entities=entities,
+            raw_thinking=data.get("thinking", ""),
+        )
+
+
+# =====================================================================
+#  Custom exception
+# =====================================================================
+
+class ExtractionError(RuntimeError):
+    """Raised when the agent cannot produce a valid extraction."""
+
+
+# ─── Quick self-test ─────────────────────────────────────────────────
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+
+    sample_text = (
+        "BULETIN DE IDENTITATE\n"
+        "Nume: POPESCU  Prenume: ION ALEXANDRU\n"
+        "CNP: 1900512345678\n"
+        "Data nașterii: 12.05.1990\n"
+        "Domiciliu: Str. Victoriei nr. 42, București, Sector 3\n"
+        "Seria: RX  Nr: 123456\n"
+    )
+
+    agent = ExtractorAgent()
+    result = agent.extract(sample_text)
+
+    print(f"\n{'='*60}")
+    print(f"Document type : {result.document_type}")
+    print(f"Summary       : {result.summary}")
+    print(f"Thinking      : {result.raw_thinking[:200]}…")
+    print(f"{'='*60}")
+    for ent in result.entities:
+        print(f"  {ent.field_name:20s} = {ent.value:30s}  (conf: {ent.confidence:.1f})")

--- a/ai/llm_config.py
+++ b/ai/llm_config.py
@@ -1,0 +1,127 @@
+"""
+LLM Configuration & Factory — ai/llm_config.py
+
+Centralized factory for obtaining LLM instances used by ALL agents in
+the ClutterKill pipeline:
+
+    - ``ck-model``       → classification agent (Agent 0 Compiler, Agent 2 Decider)
+    - ``ck-extractor``   → extraction agent (Agent 1 Extractor)
+
+Reads configuration from environment variables so it works transparently
+both on the host machine and inside the Docker ``app`` container:
+
+    AI_PROVIDER      = "ollama" | "google"         (default: "ollama")
+    OLLAMA_BASE_URL  = "http://ollama:11434"        (Docker-internal default)
+    GOOGLE_API_KEY   = "..."                        (only when provider is google)
+
+Model creation (inside Docker)::
+
+    docker exec -it clutterkill_ollama ollama create ck-model -f /app/ai/Modelfile
+    docker exec -it clutterkill_ollama ollama create ck-extractor -f /app/ai/Modelfile.extractor
+
+Usage::
+
+    from ai.llm_config import get_llm
+    llm = get_llm()                          # default → ck-model (classification)
+    llm = get_llm(model="ck-extractor")      # extraction agent
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from langchain_ollama import ChatOllama
+
+logger = logging.getLogger(__name__)
+
+# ─── Defaults (match docker-compose.yml & .env.example) ─────────────
+_DEFAULT_PROVIDER = "ollama"
+_DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434"
+_DEFAULT_REQUEST_TIMEOUT = 120.0    # seconds — OCR docs can be big
+
+# Model registry — one entry per Modelfile
+MODEL_CLASSIFIER = "ck-model"           # ai/Modelfile
+MODEL_EXTRACTOR = "ck-extractor"        # ai/Modelfile.extractor
+
+
+# =====================================================================
+#  Public API
+# =====================================================================
+
+def get_llm(
+    *,
+    model: str = MODEL_CLASSIFIER,
+    temperature: float | None = None,
+    num_ctx: int | None = None,
+    timeout: float | None = None,
+) -> ChatOllama:
+    """Return a ChatOllama instance for the requested model.
+
+    Parameters
+    ----------
+    model : str
+        Ollama model name. Use the module constants:
+        ``MODEL_CLASSIFIER`` (default) or ``MODEL_EXTRACTOR``.
+    temperature : float, optional
+        Override sampling temperature (model default: 0.1).
+    num_ctx : int, optional
+        Override context-window size.
+    timeout : float, optional
+        Override HTTP request timeout (default: 120 s).
+
+    Returns
+    -------
+    ChatOllama
+        A LangChain chat-model instance ready for ``.invoke()`` /
+        ``.ainvoke()`` / agent binding.
+    """
+    provider = os.getenv("AI_PROVIDER", _DEFAULT_PROVIDER).lower()
+
+    if provider == "google":
+        # Future: return ChatGoogleGenerativeAI(...)
+        raise NotImplementedError(
+            "Google AI provider is not yet implemented. "
+            "Set AI_PROVIDER=ollama or leave unset."
+        )
+
+    if provider != "ollama":
+        raise ValueError(
+            f"Unknown AI_PROVIDER '{provider}'. Expected 'ollama' or 'google'."
+        )
+
+    base_url = os.getenv("OLLAMA_BASE_URL", _DEFAULT_OLLAMA_BASE_URL)
+    tout = timeout if timeout is not None else _DEFAULT_REQUEST_TIMEOUT
+
+    kwargs: dict = {
+        "base_url": base_url,
+        "model": model,
+        "timeout": tout,
+    }
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+    if num_ctx is not None:
+        kwargs["num_ctx"] = num_ctx
+
+    logger.info(
+        "Initializing ChatOllama  model=%s  base_url=%s  %s",
+        model,
+        base_url,
+        {k: v for k, v in kwargs.items() if k not in ("base_url", "model", "timeout")},
+    )
+
+    llm = ChatOllama(**kwargs)
+    logger.info("ChatOllama instance ready  (%s).", model)
+    return llm
+
+
+# ── Convenience aliases ──────────────────────────────────────────────
+get_local_llm = get_llm
+
+
+# ─── Quick self-test ─────────────────────────────────────────────────
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    _llm = get_llm()
+    _resp = _llm.invoke("Hello — are you alive?")
+    print(f"[{MODEL_CLASSIFIER}] responded: {_resp.content}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 PyQt6
 langchain
 langchain-community
+langchain-ollama
+langchain-core
 PyMuPDF
 pytesseract
 pydantic

--- a/scripts/test_extractor_with_pdf.py
+++ b/scripts/test_extractor_with_pdf.py
@@ -1,0 +1,45 @@
+import fitz  # PyMuPDF
+import sys
+import os
+from ai.agent_extractor import ExtractorAgent
+
+def test_extractor_with_pdf():
+    pdf_path = "Curs_MDS_Sem2.pdf"
+
+    # Verificăm dacă fișierul există
+    if not os.path.exists(pdf_path):
+        print(f"Eroare: Fișierul {pdf_path} nu a fost găsit!")
+        print("Rulează mai întâi: docker-compose run --rm app python scripts/create_test_pdf.py")
+        sys.exit(1)
+
+    print(f"📄 Extragere text din {pdf_path} folosind PyMuPDF...")
+    doc = fitz.open(pdf_path)
+    text = ""
+    for page in doc:
+        text += page.get_text()
+    doc.close()
+
+    print("---------- CONTINUT EXTRAS ----------")
+    print(text.strip())
+    print("-------------------------------------\n")
+
+    print("🧠 Trimitere text extras către ExtractorAgent (Ollama: ck-extractor)...")
+    try:
+        agent = ExtractorAgent()
+        result = agent.extract(text)
+
+        print("\n🤖 Răspuns AI Extractor:\n")
+        print(f"{'='*60}")
+        print(f"Document type : {result.document_type}")
+        print(f"Summary       : {result.summary}")
+        print(f"Thinking      : {result.raw_thinking[:300]}…")
+        print(f"{'='*60}")
+        for ent in result.entities:
+            print(f"  {ent.field_name:20s} = {ent.value:30s}  (conf: {ent.confidence:.1f})")
+
+    except Exception as e:
+        print(f"\n❌ Eroare la comunicarea cu ExtractorAgent: {e}")
+        print("Asigură-te că containerul ollama rulează și că modelul ck-extractor a fost creat.")
+
+if __name__ == "__main__":
+    test_extractor_with_pdf()


### PR DESCRIPTION
This update introduces the core local AI infrastructure and the specialized data-extraction agent for the ClutterKill system.

Key Changes:

LLM Factory (ai/llm_config.py): Implemented a centralized, environment-aware factory (get_llm) that provisions ChatOllama instances. It supports dynamic configuration (base URLs, temperature, context size) and manages multiple model variants (ck-model and ck-extractor).
Extractor Agent (ai/agent_extractor.py): Built a "Thinking" extraction agent (Agent 1) that replaces simple parsing with a 4-step Chain-of-Thought protocol (Identify → Plan → Extract → Validate). It parses unstructured text (e.g., OCR data) into structured, Pydantic-validated JSON objects, complete with confidence scores and reasoning audit trails. Includes an automatic retry/repair loop for malformed JSON.
Ollama Modelfiles: Segregated the AI profiles into ai/Modelfile (for classification/decider roles) and ai/Modelfile.extractor (optimized for extraction with an 8K context window).
Testing & Infrastructure: Added required LangChain dependencies and created scripts/test_extractor_with_pdf.py to validate end-to-end extraction through the Dockerized Ollama ecosystem using PyMuPDF.