### PR TITLE
feat: implement SQLite quarantine database with full CRUD + tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 Curs_MDS_Sem2.pdf
 test_data/
 
+# SQLite database (generated at runtime)
+*.db
+
 # Python
 __pycache__/
 *.py[cod]

--- a/core/quarantine_db.py
+++ b/core/quarantine_db.py
@@ -1,0 +1,207 @@
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+
+# Fișierul .db se creează în rădăcina proiectului (lângă main.py)
+DEFAULT_DB_PATH = Path(__file__).parent.parent / "quarantine.db"
+
+
+class QuarantineDB:
+    """
+    Gestionează baza de date SQLite pentru fișierele aflate în carantină.
+
+    Când AI-ul nu este 100% sigur cum să clasifice un fișier, acesta este
+    adăugat în carantină în loc să fie mutat automat. Utilizatorul poate
+    apoi aproba, edita sau respinge sugestia din interfață.
+
+    Tabelul `quarantine` stochează:
+        - id: identificator unic auto-increment
+        - original_path: calea originală a fișierului pe disc
+        - ai_proposed_name: numele sugerat de AI (ex: "Factura_Enel_2026.pdf")
+        - ai_proposed_folder: folderul destinație sugerat (ex: "Facturi/Enel")
+        - reason: motivul / explicația AI-ului pentru decizia luată
+    """
+
+    def __init__(self, db_path: Optional[Path] = None):
+        self.db_path = db_path or DEFAULT_DB_PATH
+        self._init_db()
+
+    def _get_connection(self) -> sqlite3.Connection:
+        """
+        Creează și returnează o conexiune la baza de date.
+        row_factory = sqlite3.Row permite accesarea coloanelor pe nume (dict-like).
+        """
+        conn = sqlite3.connect(str(self.db_path))
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_db(self) -> None:
+        """
+        Creează tabelul `quarantine` dacă nu există deja.
+        Se apelează automat la instanțierea clasei.
+        """
+        conn = self._get_connection()
+        try:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS quarantine (
+                    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+                    original_path      TEXT    NOT NULL,
+                    ai_proposed_name   TEXT    NOT NULL,
+                    ai_proposed_folder TEXT    NOT NULL,
+                    reason             TEXT
+                )
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    # ─── CREATE ────────────────────────────────────────────────────────
+
+    def add(
+        self,
+        original_path: str,
+        ai_proposed_name: str,
+        ai_proposed_folder: str,
+        reason: str = "",
+    ) -> int:
+        """
+        Adaugă un fișier în carantină.
+
+        Args:
+            original_path: Calea originală a fișierului.
+            ai_proposed_name: Numele propus de AI.
+            ai_proposed_folder: Folderul destinație propus de AI.
+            reason: Motivul clasificării (opțional).
+
+        Returns:
+            ID-ul rândului nou inserat.
+        """
+        conn = self._get_connection()
+        try:
+            cursor = conn.execute(
+                """
+                INSERT INTO quarantine (original_path, ai_proposed_name, ai_proposed_folder, reason)
+                VALUES (?, ?, ?, ?)
+                """,
+                (original_path, ai_proposed_name, ai_proposed_folder, reason),
+            )
+            conn.commit()
+            return cursor.lastrowid
+        finally:
+            conn.close()
+
+    # ─── READ ──────────────────────────────────────────────────────────
+
+    def get_all(self) -> list[dict]:
+        """
+        Returnează toate fișierele din carantină ca o listă de dicționare.
+        """
+        conn = self._get_connection()
+        try:
+            rows = conn.execute("SELECT * FROM quarantine").fetchall()
+            return [dict(row) for row in rows]
+        finally:
+            conn.close()
+
+    def get_by_id(self, record_id: int) -> Optional[dict]:
+        """
+        Returnează un singur fișier din carantină după ID.
+
+        Returns:
+            Un dicționar cu datele fișierului, sau None dacă nu există.
+        """
+        conn = self._get_connection()
+        try:
+            row = conn.execute(
+                "SELECT * FROM quarantine WHERE id = ?", (record_id,)
+            ).fetchone()
+            return dict(row) if row else None
+        finally:
+            conn.close()
+
+    # ─── UPDATE ────────────────────────────────────────────────────────
+
+    def update(
+        self,
+        record_id: int,
+        ai_proposed_name: Optional[str] = None,
+        ai_proposed_folder: Optional[str] = None,
+        reason: Optional[str] = None,
+    ) -> bool:
+        """
+        Actualizează câmpurile unui fișier din carantină.
+        Doar câmpurile transmise (non-None) vor fi modificate.
+
+        Returns:
+            True dacă s-a actualizat cel puțin un rând, False dacă ID-ul nu există.
+        """
+        # Construim dinamic query-ul doar cu câmpurile care se schimbă
+        fields = []
+        values = []
+
+        if ai_proposed_name is not None:
+            fields.append("ai_proposed_name = ?")
+            values.append(ai_proposed_name)
+        if ai_proposed_folder is not None:
+            fields.append("ai_proposed_folder = ?")
+            values.append(ai_proposed_folder)
+        if reason is not None:
+            fields.append("reason = ?")
+            values.append(reason)
+
+        if not fields:
+            return False
+
+        values.append(record_id)
+
+        conn = self._get_connection()
+        try:
+            cursor = conn.execute(
+                f"UPDATE quarantine SET {', '.join(fields)} WHERE id = ?",
+                values,
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+        finally:
+            conn.close()
+
+    # ─── DELETE ────────────────────────────────────────────────────────
+
+    def remove(self, record_id: int) -> bool:
+        """
+        Șterge un fișier din carantină după ID.
+
+        Returns:
+            True dacă s-a șters, False dacă ID-ul nu exista.
+        """
+        conn = self._get_connection()
+        try:
+            cursor = conn.execute(
+                "DELETE FROM quarantine WHERE id = ?", (record_id,)
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+        finally:
+            conn.close()
+
+    def clear_all(self) -> int:
+        """
+        Golește complet tabelul de carantină.
+
+        Returns:
+            Numărul de rânduri șterse.
+        """
+        conn = self._get_connection()
+        try:
+            cursor = conn.execute("DELETE FROM quarantine")
+            conn.commit()
+            return cursor.rowcount
+        finally:
+            conn.close()
+
+
+# Instanță globală (la fel ca undo_manager) pentru utilizare directă în aplicație
+quarantine_db = QuarantineDB()

--- a/tests/test_quarantine_db.py
+++ b/tests/test_quarantine_db.py
@@ -1,0 +1,196 @@
+"""
+Teste pentru QuarantineDB (core/quarantine_db.py).
+
+Verifică operațiile CRUD și persistența datelor pe disc.
+Fiecare test folosește o bază de date temporară (tmp_path) ca să nu
+afecteze fișierul real quarantine.db din proiect.
+"""
+
+from core.quarantine_db import QuarantineDB
+
+
+# ─── HELPER: creează o instanță cu DB temporar ────────────────────────
+
+
+def _make_db(tmp_path):
+    """Creează o instanță QuarantineDB cu fișierul .db într-un folder temporar."""
+    return QuarantineDB(db_path=tmp_path / "test_quarantine.db")
+
+
+# ─── TEST: Adăugare (CREATE) ──────────────────────────────────────────
+
+
+def test_add_to_quarantine(tmp_path):
+    db = _make_db(tmp_path)
+
+    record_id = db.add(
+        original_path="/Users/test/Downloads/factura.pdf",
+        ai_proposed_name="Factura_Enel_2026.pdf",
+        ai_proposed_folder="Facturi/Enel",
+        reason="Factură utilități detectată",
+    )
+
+    assert record_id == 1  # Primul rând are ID-ul 1
+
+
+def test_add_multiple(tmp_path):
+    db = _make_db(tmp_path)
+
+    id1 = db.add("/path/a.pdf", "A.pdf", "FolderA", "Reason A")
+    id2 = db.add("/path/b.pdf", "B.pdf", "FolderB", "Reason B")
+    id3 = db.add("/path/c.pdf", "C.pdf", "FolderC", "Reason C")
+
+    assert id1 == 1
+    assert id2 == 2
+    assert id3 == 3
+
+
+# ─── TEST: Citire (READ) ──────────────────────────────────────────────
+
+
+def test_get_all(tmp_path):
+    db = _make_db(tmp_path)
+
+    db.add("/path/a.pdf", "A.pdf", "FolderA", "Reason A")
+    db.add("/path/b.pdf", "B.pdf", "FolderB", "Reason B")
+
+    results = db.get_all()
+
+    assert len(results) == 2
+    assert results[0]["original_path"] == "/path/a.pdf"
+    assert results[1]["ai_proposed_name"] == "B.pdf"
+
+
+def test_get_all_empty(tmp_path):
+    db = _make_db(tmp_path)
+    assert db.get_all() == []
+
+
+def test_get_by_id(tmp_path):
+    db = _make_db(tmp_path)
+
+    record_id = db.add(
+        "/Users/test/scan.pdf",
+        "Diploma_Licenta.pdf",
+        "Educatie/Diplome",
+        "Document academic detectat",
+    )
+
+    result = db.get_by_id(record_id)
+
+    assert result is not None
+    assert result["id"] == record_id
+    assert result["original_path"] == "/Users/test/scan.pdf"
+    assert result["ai_proposed_name"] == "Diploma_Licenta.pdf"
+    assert result["ai_proposed_folder"] == "Educatie/Diplome"
+    assert result["reason"] == "Document academic detectat"
+
+
+def test_get_by_id_not_found(tmp_path):
+    db = _make_db(tmp_path)
+    assert db.get_by_id(999) is None
+
+
+# ─── TEST: Actualizare (UPDATE) ───────────────────────────────────────
+
+
+def test_update_name(tmp_path):
+    db = _make_db(tmp_path)
+
+    record_id = db.add("/path/doc.pdf", "OldName.pdf", "OldFolder", "reason")
+    success = db.update(record_id, ai_proposed_name="NewName.pdf")
+
+    assert success is True
+
+    updated = db.get_by_id(record_id)
+    assert updated["ai_proposed_name"] == "NewName.pdf"
+    # Celelalte câmpuri rămân neschimbate
+    assert updated["ai_proposed_folder"] == "OldFolder"
+
+
+def test_update_multiple_fields(tmp_path):
+    db = _make_db(tmp_path)
+
+    record_id = db.add("/path/doc.pdf", "Old.pdf", "OldFolder", "old reason")
+    db.update(
+        record_id,
+        ai_proposed_name="New.pdf",
+        ai_proposed_folder="NewFolder",
+        reason="new reason",
+    )
+
+    updated = db.get_by_id(record_id)
+    assert updated["ai_proposed_name"] == "New.pdf"
+    assert updated["ai_proposed_folder"] == "NewFolder"
+    assert updated["reason"] == "new reason"
+
+
+def test_update_nonexistent(tmp_path):
+    db = _make_db(tmp_path)
+    assert db.update(999, ai_proposed_name="X.pdf") is False
+
+
+def test_update_no_fields(tmp_path):
+    db = _make_db(tmp_path)
+    record_id = db.add("/path/doc.pdf", "Name.pdf", "Folder", "reason")
+    # Dacă nu pasăm niciun câmp, returnează False
+    assert db.update(record_id) is False
+
+
+# ─── TEST: Ștergere (DELETE) ──────────────────────────────────────────
+
+
+def test_remove(tmp_path):
+    db = _make_db(tmp_path)
+
+    record_id = db.add("/path/doc.pdf", "Name.pdf", "Folder", "reason")
+    assert db.remove(record_id) is True
+    assert db.get_by_id(record_id) is None
+
+
+def test_remove_nonexistent(tmp_path):
+    db = _make_db(tmp_path)
+    assert db.remove(999) is False
+
+
+def test_clear_all(tmp_path):
+    db = _make_db(tmp_path)
+
+    db.add("/path/a.pdf", "A.pdf", "FolderA", "")
+    db.add("/path/b.pdf", "B.pdf", "FolderB", "")
+    db.add("/path/c.pdf", "C.pdf", "FolderC", "")
+
+    deleted_count = db.clear_all()
+
+    assert deleted_count == 3
+    assert db.get_all() == []
+
+
+# ─── TEST: Persistență (datele rămân după reconectare) ────────────────
+
+
+def test_data_persists_after_reopen(tmp_path):
+    """
+    Verificare critică: datele trebuie să existe și după ce
+    închidem și redeschidem baza de date (simulează restart aplicație).
+    """
+    db_path = tmp_path / "persist_test.db"
+
+    # Prima sesiune - adăugăm date
+    db1 = QuarantineDB(db_path=db_path)
+    db1.add(
+        "/Users/test/Downloads/mystery.pdf",
+        "Factura_Orange_2026.pdf",
+        "Facturi/Telecom",
+        "Factură telecom detectată",
+    )
+
+    # A doua sesiune - redeschidem baza de date (simulăm restart)
+    db2 = QuarantineDB(db_path=db_path)
+    results = db2.get_all()
+
+    assert len(results) == 1
+    assert results[0]["original_path"] == "/Users/test/Downloads/mystery.pdf"
+    assert results[0]["ai_proposed_name"] == "Factura_Orange_2026.pdf"
+    assert results[0]["ai_proposed_folder"] == "Facturi/Telecom"
+    assert results[0]["reason"] == "Factură telecom detectată"


### PR DESCRIPTION
- Implemented QuarantineDB class in core/quarantine_db.py using sqlite3
- Table stores: id, original_path, ai_proposed_name, ai_proposed_folder, reason
- CRUD operations: add, get_all, get_by_id, update, remove, clear_all
- Added 14 tests including persistence verification after DB reopen
- Added *.db to .gitignore to exclude runtime database files